### PR TITLE
Multi-chain DXstats links

### DIFF
--- a/src/components/Header/MobileOptions.tsx
+++ b/src/components/Header/MobileOptions.tsx
@@ -8,6 +8,7 @@ import { MoreHorizontal, X } from 'react-feather'
 import { RowFixed } from '../Row'
 import { darken, transparentize } from 'polished'
 import { useTranslation } from 'react-i18next'
+import { useActiveWeb3React } from '../../hooks'
 
 const StyledMenu = styled.div`
   margin-left: 0.5rem;
@@ -85,12 +86,13 @@ const StyledExternalLink = styled(ExternalLink)<{ isActive?: boolean }>`
   }
 `
 
-export default function MobileOptions({ history }: { history: any }) {
+export default function MobileOptions() {
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.MOBILE)
   const toggle = useToggleMobileMenu()
   const { t } = useTranslation()
   useOnClickOutside(node, open ? toggle : undefined)
+  const { chainId } = useActiveWeb3React()
 
   const handleDisabledAnchorClick = useCallback(event => {
     event.preventDefault()
@@ -110,7 +112,7 @@ export default function MobileOptions({ history }: { history: any }) {
               </StyledNavLinkWithBadge>
             </RowFixed>
             <RowFixed style={{ alignSelf: 'center', margin: '1rem' }}>
-              <StyledExternalLink id={`stake-nav-link`} href={'https://dxstats.eth.link/'}>
+              <StyledExternalLink id={`stake-nav-link`} href={`https://dxstats.eth.link/?chainId=${chainId}`}>
                 Charts <span style={{ fontSize: '11px' }}>↗</span>
               </StyledExternalLink>
             </RowFixed>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -224,7 +224,7 @@ const StyledExternalLink = styled(ExternalLink).attrs({
 `
 
 function Header({ history }: { history: any }) {
-  const { account } = useActiveWeb3React()
+  const { account, chainId } = useActiveWeb3React()
   const { t } = useTranslation()
 
   const nativeCurrency = useNativeCurrency()
@@ -268,7 +268,7 @@ function Header({ history }: { history: any }) {
               </Box>
             </AbsoluteComingSoonBadgeFlex>
           </StyledNavLinkWithBadge>
-          <StyledExternalLink id={`stake-nav-link`} href={'https://dxstats.eth.link/'}>
+          <StyledExternalLink id={`stake-nav-link`} href={`http://dxstats.eth.link/#/?chainId=${chainId}`}>
             Charts{' '}
             <Text ml="4px" fontSize="11px">
               ↗
@@ -278,7 +278,7 @@ function Header({ history }: { history: any }) {
             <Settings />
           </MobileSettingsWrap>
           <MoreLinksIcon>
-            <MobileOptions history={history} />
+            <MobileOptions />
           </MoreLinksIcon>
         </HeaderLinks>
       </HeaderRow>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -268,7 +268,7 @@ function Header({ history }: { history: any }) {
               </Box>
             </AbsoluteComingSoonBadgeFlex>
           </StyledNavLinkWithBadge>
-          <StyledExternalLink id={`stake-nav-link`} href={`http://dxstats.eth.link/#/?chainId=${chainId}`}>
+          <StyledExternalLink id={`stake-nav-link`} href={`https://dxstats.eth.link/#/?chainId=${chainId}`}>
             Charts{' '}
             <Text ml="4px" fontSize="11px">
               ↗

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -69,7 +69,7 @@ const EmptyProposals = styled.div`
 `
 
 export default function Pool() {
-  const { account } = useActiveWeb3React()
+  const { account, chainId } = useActiveWeb3React()
 
   // fetch the user's balances of all tracked DXSwap LP tokens
   const trackedTokenPairs = useTrackedTokenPairs()
@@ -142,17 +142,28 @@ export default function Pool() {
             )}
           </AutoColumn>
         </AutoColumn>
-        <ButtonWithLink
-          link={`https://dxstats.eth.link/#/account/${account}`}
-          text={'ACCOUNT ANALYTICS AND ACCRUED FEES'}
-          marginTop="32px"
-        />
-        <TYPE.body color="text4" textAlign="center" fontWeight="500" fontSize="14px" lineHeight="17px" marginTop="32px">
-          Don't see a pool you joined?{' '}
-          <StyledInternalLink color="text5" id="import-pool-link" to="/find">
-            Import it.
-          </StyledInternalLink>
-        </TYPE.body>
+        {account && chainId && (
+          <>
+            <ButtonWithLink
+              link={`https://dxstats.eth.link/#/account/${account}?chainId=${chainId}`}
+              text={'ACCOUNT ANALYTICS AND ACCRUED FEES'}
+              marginTop="32px"
+            />
+            <TYPE.body
+              color="text4"
+              textAlign="center"
+              fontWeight="500"
+              fontSize="14px"
+              lineHeight="17px"
+              marginTop="32px"
+            >
+              Don't see a pool you joined?{' '}
+              <StyledInternalLink color="text5" id="import-pool-link" to="/find">
+                Import it.
+              </StyledInternalLink>
+            </TYPE.body>
+          </>
+        )}
 
         <VoteCard style={{ marginTop: '32px' }}>
           <CardSection>
@@ -168,8 +179,8 @@ export default function Pool() {
                   the pool.
                   <br /> Fees are added to the pool, accrue in real time and can be claimed by withdrawing your
                   liquidity.
-                  <br /> The swap fee value is decided by DXdao and liquidity providers, it can be between 0% and 10% and
-                  it uses 0.25% as default value that is assigned when the pair is created.
+                  <br /> The swap fee value is decided by DXdao and liquidity providers, it can be between 0% and 10%
+                  and it uses 0.25% as default value that is assigned when the pair is created.
                 </TYPE.body>
               </RowBetween>
               {/*<RowBetween>*/}


### PR DESCRIPTION
While waiting for the next DXstats release, that will introduce multi-chain data, I've updated the current DXstats links to include the targeted chain id. Once DXstats will be released, Swapr will tie in seamlessly.