### PR TITLE
WalletConnect targeted chain chainge

### DIFF
--- a/src/components/NetworkSwitcherPopover/index.tsx
+++ b/src/components/NetworkSwitcherPopover/index.tsx
@@ -13,6 +13,7 @@ import { useActiveWeb3React } from '../../hooks'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import { NETWORK_DETAIL } from '../../constants'
 import { CustomNetworkConnector } from '../../connectors/CustomNetworkConnector'
+import { walletConnect } from '../../connectors'
 
 const OptionGrid = styled.div`
   display: grid;
@@ -38,8 +39,12 @@ export default function NetworkSwitcherPopover({ children }: { children: ReactNo
   const selectNetwork = useCallback(
     (optionChainId: ChainId) => {
       if (optionChainId === chainId) return
-      if (!!!account && connector instanceof CustomNetworkConnector) {
-        connector.changeChainId(optionChainId)
+      if (!!!account) {
+        if (connector instanceof CustomNetworkConnector) {
+          connector.changeChainId(optionChainId)
+        }
+        // change walletconnect's targeted chain to be in sync with what user expects
+        walletConnect.targetedChainId = optionChainId
       }
       if (
         window.ethereum &&

--- a/src/components/NetworkSwitcherPopover/index.tsx
+++ b/src/components/NetworkSwitcherPopover/index.tsx
@@ -13,7 +13,6 @@ import { useActiveWeb3React } from '../../hooks'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import { NETWORK_DETAIL } from '../../constants'
 import { CustomNetworkConnector } from '../../connectors/CustomNetworkConnector'
-import { walletConnect } from '../../connectors'
 
 const OptionGrid = styled.div`
   display: grid;
@@ -39,13 +38,7 @@ export default function NetworkSwitcherPopover({ children }: { children: ReactNo
   const selectNetwork = useCallback(
     (optionChainId: ChainId) => {
       if (optionChainId === chainId) return
-      if (!!!account) {
-        if (connector instanceof CustomNetworkConnector) {
-          connector.changeChainId(optionChainId)
-        }
-        // change walletconnect's targeted chain to be in sync with what user expects
-        walletConnect.targetedChainId = optionChainId
-      }
+      if (!!!account && connector instanceof CustomNetworkConnector) connector.changeChainId(optionChainId)
       if (
         window.ethereum &&
         window.ethereum.isMetaMask &&

--- a/src/components/WalletModal/PendingView.tsx
+++ b/src/components/WalletModal/PendingView.tsx
@@ -76,7 +76,7 @@ export default function PendingView({
             }
           }
           return (
-            <Flex mb="28px" justifyContent="center">
+            <Flex key={key} mb="28px" justifyContent="center">
               <Box mr="10px">
                 <img src={require('../../assets/images/' + option.iconName)} alt="logo" width="24px" height="24px" />
               </Box>

--- a/src/connectors/CustomWalletConnectConnector.ts
+++ b/src/connectors/CustomWalletConnectConnector.ts
@@ -1,0 +1,135 @@
+// largely taken from https://github.com/NoahZinsmeister/web3-react/blob/v6/packages/walletconnect-connector/src/index.ts
+// Implements a function to change targeted connection chain id. When no account is connected and the user switches
+// chains in the network switcher, the WalletConnect targeted chain changes too.
+
+import { ConnectorUpdate } from '@web3-react/types'
+import { AbstractConnector } from '@web3-react/abstract-connector'
+import { IWalletConnectProviderOptions } from '@walletconnect/types'
+
+export const URI_AVAILABLE = 'URI_AVAILABLE'
+
+export interface WalletConnectConnectorArguments extends IWalletConnectProviderOptions {
+  supportedChainIds?: number[]
+  targetedChainId: number
+}
+
+export class UserRejectedRequestError extends Error {
+  public constructor() {
+    super()
+    this.name = this.constructor.name
+    this.message = 'The user rejected the request.'
+  }
+}
+
+function getSupportedChains({ supportedChainIds, rpc }: WalletConnectConnectorArguments): number[] | undefined {
+  if (supportedChainIds) {
+    return supportedChainIds
+  }
+
+  return rpc ? Object.keys(rpc).map(k => Number(k)) : undefined
+}
+
+export class CustomWalletConnectConnector extends AbstractConnector {
+  private readonly config: WalletConnectConnectorArguments
+
+  public walletConnectProvider?: any
+
+  constructor(config: WalletConnectConnectorArguments) {
+    super({ supportedChainIds: getSupportedChains(config) })
+    if (this.supportedChainIds?.indexOf(config.targetedChainId) === -1)
+      throw new Error(`unsupported targeted chain id ${config.targetedChainId}`)
+
+    this.config = config
+
+    this.handleChainChanged = this.handleChainChanged.bind(this)
+    this.handleAccountsChanged = this.handleAccountsChanged.bind(this)
+    this.handleDisconnect = this.handleDisconnect.bind(this)
+  }
+
+  private handleChainChanged(chainId: number | string): void {
+    this.emitUpdate({ chainId })
+  }
+
+  private handleAccountsChanged(accounts: string[]): void {
+    this.emitUpdate({ account: accounts[0] })
+  }
+
+  private handleDisconnect(): void {
+    this.emitDeactivate()
+    // we have to do this because of a @walletconnect/web3-provider bug
+    if (this.walletConnectProvider) {
+      this.walletConnectProvider.stop()
+      this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
+      this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
+      this.walletConnectProvider = undefined
+    }
+
+    this.emitDeactivate()
+  }
+
+  public async activate(): Promise<ConnectorUpdate> {
+    if (!this.walletConnectProvider) {
+      const WalletConnectProvider = await import('@walletconnect/web3-provider').then(m => m?.default ?? m)
+      this.walletConnectProvider = new WalletConnectProvider(this.config)
+    }
+
+    // ensure that the uri is going to be available, and emit an event if there's a new uri
+    if (!this.walletConnectProvider.wc.connected) {
+      await this.walletConnectProvider.wc.createSession({ chainId: this.config.targetedChainId })
+      this.emit(URI_AVAILABLE, this.walletConnectProvider.wc.uri)
+    }
+
+    const account = await this.walletConnectProvider
+      .enable()
+      .then((accounts: string[]): string => accounts[0])
+      .catch((error: Error): void => {
+        // TODO ideally this would be a better check
+        if (error.message === 'User closed modal') {
+          throw new UserRejectedRequestError()
+        }
+
+        throw error
+      })
+
+    this.walletConnectProvider.on('disconnect', this.handleDisconnect)
+    this.walletConnectProvider.on('chainChanged', this.handleChainChanged)
+    this.walletConnectProvider.on('accountsChanged', this.handleAccountsChanged)
+
+    return { provider: this.walletConnectProvider, account }
+  }
+
+  public async getProvider(): Promise<any> {
+    return this.walletConnectProvider
+  }
+
+  public async getChainId(): Promise<number | string> {
+    return this.walletConnectProvider.send('eth_chainId')
+  }
+
+  public async getAccount(): Promise<null | string> {
+    return this.walletConnectProvider.send('eth_accounts').then((accounts: string[]): string => accounts[0])
+  }
+
+  public deactivate() {
+    if (this.walletConnectProvider) {
+      this.walletConnectProvider.stop()
+      this.walletConnectProvider.removeListener('disconnect', this.handleDisconnect)
+      this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
+      this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
+    }
+  }
+
+  public async close() {
+    await this.walletConnectProvider?.close()
+  }
+
+  public set targetedChainId(newTargetedChainId: number) {
+    if (this.supportedChainIds?.indexOf(newTargetedChainId) === -1)
+      throw new Error(`unsupported targeted chain id ${newTargetedChainId}`)
+    this.config.targetedChainId = newTargetedChainId
+  }
+
+  public get targetedChainId(): number {
+    return this.config.targetedChainId
+  }
+}

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -22,7 +22,6 @@ export const injected = new InjectedConnector({
 
 // mainnet only
 export const walletConnect = new CustomWalletConnectConnector({
-  targetedChainId: ChainId.MAINNET,
   rpc: {
     [ChainId.XDAI]: 'https://rpc.xdaichain.com/',
     [ChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,7 +1,7 @@
 import { InjectedConnector } from '@web3-react/injected-connector'
 import { AuthereumConnector } from '@web3-react/authereum-connector'
-import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import { CustomNetworkConnector } from './CustomNetworkConnector'
+import { CustomWalletConnectConnector } from './CustomWalletConnectConnector'
 import { ChainId } from 'dxswap-sdk'
 import { providers } from 'ethers'
 import getLibrary from '../utils/getLibrary'
@@ -21,10 +21,11 @@ export const injected = new InjectedConnector({
 })
 
 // mainnet only
-export const walletConnect = new WalletConnectConnector({
+export const walletConnect = new CustomWalletConnectConnector({
+  targetedChainId: ChainId.MAINNET,
   rpc: {
-    1: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
-    100: 'https://rpc.xdaichain.com/'
+    [ChainId.XDAI]: 'https://rpc.xdaichain.com/',
+    [ChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
   },
   bridge: 'https://bridge.walletconnect.org',
   qrcode: true,


### PR DESCRIPTION
Makes WalletConnect's targeted chain, and user-selected chain from network switcher in sync. I.e. if a user selects xDai from the network switcher, and later initiates a WalletConnect connection, the connection will refer to xDai.