### PR TITLE
Feature - ENS Avatar support

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "arb-ts": "^0.0.42",
+    "multiformats": "^9.4.10",
     "query-string": "^6.13.8",
     "react-use": "^15.3.3"
   }

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -28,8 +28,8 @@ const StyledMenuIconContainer = styled.div`
   justify-content: center;
   align-items: center;
   padding: 0px 8px;
-  height: 29px;
-  width: 29px;
+  height: 32px;
+  width: 32px;
   cursor: pointer;
   background: ${props => props.theme.dark1};
   border-radius: 12px;
@@ -69,7 +69,6 @@ const EmojiWrapper = styled.div`
 const StyledMenu = styled.button`
   height: 32px;
   width: 32px;
-  padding: 6px 8px;
   border-radius: 12px;
   margin-left: 7px;
   display: flex;

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -38,6 +38,7 @@ const View = styled.div`
   border-radius: 12px;
   white-space: nowrap;
   margin-left: 8px;
+  padding: 1px;
 `
 
 const Web3StatusConnected = styled.button<{ pending?: boolean }>`
@@ -60,7 +61,7 @@ const Web3StatusConnected = styled.button<{ pending?: boolean }>`
 const Web3StatusNetwork = styled.button<{ pendingTransactions?: boolean; isConnected: boolean; clickable: boolean }>`
   display: flex;
   align-items: center;
-  height: 28px;
+  height: 26px;
   padding: 7px 8px;
   font-size: 12px;
   line-height: 15px;

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -119,7 +119,7 @@ const Avatar = styled.div<StyledAvatarProps>(props => ({
   width: 32,
   borderRadius: '50%',
   marginRight: 6,
-  marginLeft: -12,
+  marginLeft: -14,
   backgroundColor: props.theme.bg1,
   backgroundSize: 'cover',
   backgroundImage: `url(${props.url})`

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -110,13 +110,20 @@ const AddressMobile = styled.span`
   `};
 `
 
-const Avatar = styled.img({
-  maxHeight: '100%',
-  maxWidth: '100%',
+export interface StyledAvatarProps {
+  url: string
+}
+
+const Avatar = styled.div<StyledAvatarProps>(props => ({
+  height: 32,
+  width: 32,
   borderRadius: '50%',
   marginRight: 6,
-  marginLeft: -12
-})
+  marginLeft: -12,
+  backgroundColor: props.theme.bg1,
+  backgroundSize: 'cover',
+  backgroundImage: `url(${props.url})`
+}))
 
 interface AccountStatusProps {
   pendingTransactions: string[]
@@ -160,7 +167,7 @@ export function AccountStatus({
             </RowBetween>
           ) : ENSName ? (
             <>
-              {avatar && <Avatar alt={ENSName} src={avatar.image} />}
+              {avatar && <Avatar url={avatar.image} />}
               <>{ENSName}</>
             </>
           ) : (

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -60,7 +60,7 @@ const Web3StatusConnected = styled.button<{ pending?: boolean }>`
 const Web3StatusNetwork = styled.button<{ pendingTransactions?: boolean; isConnected: boolean; clickable: boolean }>`
   display: flex;
   align-items: center;
-  height: 25px;
+  height: 28px;
   padding: 7px 8px;
   font-size: 12px;
   line-height: 15px;
@@ -68,7 +68,7 @@ const Web3StatusNetwork = styled.button<{ pendingTransactions?: boolean; isConne
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #ffffff;
-  border-radius: 12px;
+  border-radius: 10px;
   background-color: ${({ theme, isConnected }) => (isConnected ? theme.dark2 : 'transparent')};
   border: none;
   outline: none;

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -17,6 +17,7 @@ import { CustomNetworkConnector } from '../../connectors/CustomNetworkConnector'
 import { InjectedConnector } from '@web3-react/injected-connector'
 import { ApplicationModal } from '../../state/application/actions'
 import { ChainLabel } from '../../constants'
+import { ENSAvatarData } from '../../hooks/useENSAvatar'
 
 const ChainLogo: any = {
   [ChainId.MAINNET]: EthereumLogo,
@@ -52,6 +53,8 @@ const Web3StatusConnected = styled.button<{ pending?: boolean }>`
   text-transform: uppercase;
   cursor: pointer;
   outline: none;
+  display: flex;
+  align-items: center;
 `
 
 const Web3StatusNetwork = styled.button<{ pendingTransactions?: boolean; isConnected: boolean; clickable: boolean }>`
@@ -107,9 +110,18 @@ const AddressMobile = styled.span`
   `};
 `
 
+const Avatar = styled.img({
+  maxHeight: '100%',
+  maxWidth: '100%',
+  borderRadius: '50%',
+  marginRight: 6,
+  marginLeft: -12
+})
+
 interface AccountStatusProps {
   pendingTransactions: string[]
   ENSName?: string
+  avatar?: ENSAvatarData
   account: string | undefined | null
   connector: AbstractConnector | undefined
   networkConnectorChainId: ChainId | undefined
@@ -122,7 +134,8 @@ export function AccountStatus({
   account,
   connector,
   networkConnectorChainId,
-  onAddressClick
+  onAddressClick,
+  avatar
 }: AccountStatusProps) {
   const hasPendingTransactions = !!pendingTransactions.length
   const toggleNetworkSwitcherPopover = useNetworkSwitcherPopoverToggle()
@@ -145,13 +158,16 @@ export function AccountStatus({
               </Text>{' '}
               <Loader />
             </RowBetween>
+          ) : ENSName ? (
+            <>
+              {avatar && <Avatar alt={ENSName} src={avatar.image} />}
+              <>{ENSName}</>
+            </>
           ) : (
-            ENSName || (
-              <>
-                <AddressDesktop>{shortenAddress(account)}</AddressDesktop>
-                <AddressMobile>{shortenAddress(account, 2)}</AddressMobile>
-              </>
-            )
+            <>
+              <AddressDesktop>{shortenAddress(account)}</AddressDesktop>
+              <AddressMobile>{shortenAddress(account, 2)}</AddressMobile>
+            </>
           )}
         </Web3StatusConnected>
       )}

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -28,7 +28,7 @@ const ChainLogo: any = {
 }
 
 const View = styled.div`
-  height: 29px;
+  height: 32px;
   display: flex;
   align-items: center;
   margin-left: auto;

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -17,6 +17,7 @@ import { TriangleIcon } from '../Icons'
 import { useTranslation } from 'react-i18next'
 import Row from '../Row'
 import { useIsMobileByMedia } from '../../hooks/useIsMobileByMedia'
+import { useENSAvatar } from '../../hooks/useENSAvatar'
 import { ApplicationModal } from '../../state/application/actions'
 
 const Web3StatusError = styled.div`
@@ -88,7 +89,7 @@ export default function Web3Status() {
   const contextNetwork = useWeb3React(NetworkContextName)
 
   const { ENSName } = useENSName(account ?? undefined)
-
+  const { avatar: ensAvatar } = useENSAvatar(ENSName)
   const allTransactions = useAllTransactions()
 
   const sortedRecentTransactions = useMemo(() => {
@@ -163,6 +164,7 @@ export default function Web3Status() {
             connector={activeConnector}
             networkConnectorChainId={networkConnectorChainId}
             onAddressClick={() => setModal(ModalView.Account)}
+            avatar={ensAvatar ?? undefined}
           />
         </Row>
       </ConnectWalletPopover>

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -1,0 +1,92 @@
+import { useWeb3React } from '@web3-react/core'
+import { useEffect, useState } from 'react'
+
+// @ts-nocheck
+const { CID } = require('multiformats/esm/src/cid')
+
+const IPFS_GATEWAY = 'https://ipfs.io/ipfs/'
+
+export interface ENSAvatarData {
+  uri: string
+  host_meta: {
+    chain_id: number
+    namespace: string
+    contract_address: string
+    token_id: string
+    reference_url: string
+  }
+  is_owner: boolean
+  description: string
+  image: string
+  name: string
+}
+
+export interface UseENSAvatarReturn {
+  loading: boolean
+  data?: ENSAvatarData
+}
+
+export function isCID(hash: string) {
+  try {
+    if (typeof hash === 'string') {
+      return Boolean(CID.parse(hash))
+    }
+    return Boolean(CID.asCID(hash))
+  } catch (e) {
+    return false
+  }
+}
+
+// Map chainId to network name for fetch request
+const supportedENSNetworks: { [chainId: number]: string } = {
+  1: 'mainnet',
+  4: 'rinkeby'
+}
+// List of chains where ENS is deployed
+const supportedENSChainIds = [1, 4]
+// List of supported procotols that can be resovled to a URI
+
+/**
+ * Does a lookup for an ENS name to find its avatar details, uses ENS Domains metadata API
+ */
+export function useENSAvatar(ensName?: string | null) {
+  const [avatar, setAvatar] = useState<ENSAvatarData>()
+  const [loading, setLoading] = useState<boolean>(true)
+  const { chainId } = useWeb3React()
+
+  useEffect(() => {
+    // ENS supports Mainnet and Rinkeby
+    if (!supportedENSChainIds.includes(chainId as number) || !ensName) {
+      setLoading(false)
+      return
+    }
+
+    const networkName = supportedENSNetworks[chainId as number]
+
+    fetch(`https://metadata.ens.domains/${networkName}/avatar/${ensName}/meta`)
+      .then(res => res.json())
+      .then(data => {
+        if ('image' in data && data.image) {
+          if (data.image.startsWith('ipfs://ipfs/')) {
+            data.image = data.image.replace('ipfs://ipfs/', IPFS_GATEWAY)
+          } else if (data.image.startsWith('ipfs://')) {
+            data.image = data.image.replace('ipfs://', IPFS_GATEWAY)
+          } else if (data.image.startsWith('ipfs/')) {
+            data.image = data.image.replace('ipfs/', IPFS_GATEWAY)
+          } else if (isCID(data.image)) {
+            data.image = `${IPFS_GATEWAY}${data.image}`
+          }
+        }
+        setAvatar(data)
+        setLoading(false)
+      })
+      .catch(e => {
+        console.error('useAvatar error: ', e)
+      })
+  }, [chainId, ensName])
+
+  return {
+    loading,
+    avatar
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10870,6 +10870,11 @@ multicodec@^3.0.1:
     uint8arrays "^2.1.3"
     varint "^5.0.2"
 
+multiformats@^9.4.10:
+  version "9.4.10"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.10.tgz#d654d06b28cc066506e4e59b246d65267fb6b93b"
+  integrity sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA==
+
 multihashes@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-3.1.2.tgz#ffa5e50497aceb7911f7b4a3b6cada9b9730edfc"


### PR DESCRIPTION
### Summary

Adds `useENSAvatar` hook which retrieves the current EOA avatar from the ENS Metadata API. Feel free to suggest a better way. 

- Closes #481 

## Pitfalls

Haven't tested the mobile view.

### To Test

You need a wallet with ENS avatar, the best way I found is to impersonate a wallet using [Impersonator](https://apoorvlathey.com/impersonator/) and WalletConnect.

ENS Wallets with avatars:

- nick.eth, works on 1inch and Swapr but not Uniswap.
- brantly.eth, has the avatar but doesn't work 1inch Swapr nor Uniswap.


More ENS names from https://twitter.com/BrantlyMillegan/status/1456640949052973065

