### PR TITLE
fix: some liquidity mining campaigns are not showing

### DIFF
--- a/src/hooks/useAllLiquidtyMiningCampaigns.ts
+++ b/src/hooks/useAllLiquidtyMiningCampaigns.ts
@@ -20,7 +20,7 @@ const CAMPAIGN_COMMON_FIEDLDS = ['duration', 'startsAt', 'endsAt', 'locked', 'st
 
 const SINGLE_SIDED_CAMPAIGNS = gql`
   query($userId: ID) {
-    singleSidedStakingCampaigns {
+    singleSidedStakingCampaigns(first: 999) {
       id
       owner
       ${CAMPAIGN_COMMON_FIEDLDS.join('\r\n')}
@@ -46,7 +46,7 @@ const SINGLE_SIDED_CAMPAIGNS = gql`
 `
 const REGULAR_CAMPAIGN = gql`
   query($userId: ID) {
-    liquidityMiningCampaigns {
+    liquidityMiningCampaigns(first: 999) {
       address: id
       ${CAMPAIGN_COMMON_FIEDLDS.join('\r\n')}
       rewards {


### PR DESCRIPTION
A regression was introduced in Beta 10 where the query to The Graph is only fetching the first 100 campaigns (by default). Increasing the limit to 999 as **a quick fix, for now,** fixes this. 