### PR TITLE
Fix multi rewards campaigns claimable and claimed token amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "@swapr/core": "^0.3.18",
     "@swapr/periphery": "^0.3.20",
-    "@swapr/sdk": "^0.11.0",
+    "@swapr/sdk": "^0.11.1",
     "@types/aos": "^3.0.4",
     "@types/jest": "^25.2.1",
     "@types/lodash.flatmap": "^4.5.6",

--- a/src/hooks/useLiquidityMiningCampaignPosition.ts
+++ b/src/hooks/useLiquidityMiningCampaignPosition.ts
@@ -1,9 +1,10 @@
-import { LiquidityMiningCampaign, PricedTokenAmount, SingleSidedLiquidityMiningCampaign } from '@swapr/sdk'
+import { LiquidityMiningCampaign, PricedToken, PricedTokenAmount, SingleSidedLiquidityMiningCampaign } from '@swapr/sdk'
 import { useMemo } from 'react'
 import { useStakingRewardsDistributionContract } from './useContract'
-import { useSingleCallResult } from '../state/multicall/hooks'
+import { useSingleCallResult, useSingleContractMultipleData } from '../state/multicall/hooks'
 import { useActiveWeb3React } from '.'
 import { BigNumber } from 'ethers'
+import { getAddress } from 'ethers/lib/utils'
 
 interface UseLiquidityMiningCampaignUserPositionHookResult {
   stakedTokenAmount: PricedTokenAmount | null
@@ -20,9 +21,16 @@ export function useLiquidityMiningCampaignPosition(
 
   const distributionContract = useStakingRewardsDistributionContract(campaign?.address, true)
 
-  const claimedRewardsResult = useSingleCallResult(distributionContract, 'getClaimedRewards', [account])
-  const stakedTokensOfResult = useSingleCallResult(distributionContract, 'stakedTokensOf', [account])
-  const claimableRewardsResult = useSingleCallResult(distributionContract, 'claimableRewards', [account])
+  const rewardIndexParams = useMemo(
+    () => (campaign ? campaign.rewards.map((_: any, index: number) => [index]) : [undefined]),
+    [campaign]
+  )
+  const accountParam = useMemo(() => [account], [account])
+
+  const rewardsResults = useSingleContractMultipleData(distributionContract, 'rewards', rewardIndexParams)
+  const claimedRewardsResult = useSingleCallResult(distributionContract, 'getClaimedRewards', accountParam)
+  const stakedTokensOfResult = useSingleCallResult(distributionContract, 'stakedTokensOf', accountParam)
+  const claimableRewardsResult = useSingleCallResult(distributionContract, 'claimableRewards', accountParam)
 
   return useMemo(() => {
     if (
@@ -30,7 +38,10 @@ export function useLiquidityMiningCampaignPosition(
       !chainId ||
       !claimableRewardsResult.result ||
       !stakedTokensOfResult.result ||
-      !claimedRewardsResult.result
+      !claimedRewardsResult.result ||
+      !rewardsResults ||
+      rewardsResults.length === 0 ||
+      rewardsResults.some(result => !result.result)
     )
       return {
         stakedTokenAmount: null,
@@ -38,15 +49,25 @@ export function useLiquidityMiningCampaignPosition(
         claimableRewardAmounts: [],
         totalRewardedAmounts: []
       }
+
+    const rewardTokenAddresses = rewardsResults.map(wrappedResult => wrappedResult?.result?.[0])
     const stakedTokensOf = stakedTokensOfResult.result[0] as BigNumber
     const claimedRewards = claimedRewardsResult.result[0] as BigNumber[]
     const claimableRewards = claimableRewardsResult.result[0] as BigNumber[]
 
+    const rewardToken = campaign.rewards.reduce(
+      (accumulator: { [address: string]: PricedToken }, reward: PricedTokenAmount) => {
+        accumulator[getAddress(reward.token.address)] = reward.token
+        return accumulator
+      },
+      {}
+    )
+
     const claimedRewardAmounts = claimedRewards.map(
-      (claimed, index) => new PricedTokenAmount(campaign.rewards[index].token, claimed.toString())
+      (claimed, index) => new PricedTokenAmount(rewardToken[rewardTokenAddresses[index]], claimed.toString())
     )
     const claimableRewardAmounts = claimableRewards.map(
-      (claimable, index) => new PricedTokenAmount(campaign.rewards[index].token, claimable.toString())
+      (claimable, index) => new PricedTokenAmount(rewardToken[rewardTokenAddresses[index]], claimable.toString())
     )
     const totalRewardedAmounts = claimableRewardAmounts.map(
       (claimable, index) => new PricedTokenAmount(claimable.token, claimable.add(claimedRewardAmounts[index]).raw)
@@ -58,5 +79,12 @@ export function useLiquidityMiningCampaignPosition(
       claimableRewardAmounts,
       totalRewardedAmounts
     }
-  }, [campaign, chainId, claimableRewardsResult.result, claimedRewardsResult.result, stakedTokensOfResult.result])
+  }, [
+    campaign,
+    chainId,
+    claimableRewardsResult.result,
+    claimedRewardsResult.result,
+    rewardsResults,
+    stakedTokensOfResult.result
+  ])
 }

--- a/src/hooks/useLiquidityMiningCampaignPosition.ts
+++ b/src/hooks/useLiquidityMiningCampaignPosition.ts
@@ -55,7 +55,7 @@ export function useLiquidityMiningCampaignPosition(
     const claimedRewards = claimedRewardsResult.result[0] as BigNumber[]
     const claimableRewards = claimableRewardsResult.result[0] as BigNumber[]
 
-    const rewardToken = campaign.rewards.reduce(
+    const rewardTokens = campaign.rewards.reduce(
       (accumulator: { [address: string]: PricedToken }, reward: PricedTokenAmount) => {
         accumulator[getAddress(reward.token.address)] = reward.token
         return accumulator
@@ -64,10 +64,10 @@ export function useLiquidityMiningCampaignPosition(
     )
 
     const claimedRewardAmounts = claimedRewards.map(
-      (claimed, index) => new PricedTokenAmount(rewardToken[rewardTokenAddresses[index]], claimed.toString())
+      (claimed, index) => new PricedTokenAmount(rewardTokens[rewardTokenAddresses[index]], claimed.toString())
     )
     const claimableRewardAmounts = claimableRewards.map(
-      (claimable, index) => new PricedTokenAmount(rewardToken[rewardTokenAddresses[index]], claimable.toString())
+      (claimable, index) => new PricedTokenAmount(rewardTokens[rewardTokenAddresses[index]], claimable.toString())
     )
     const totalRewardedAmounts = claimableRewardAmounts.map(
       (claimable, index) => new PricedTokenAmount(claimable.token, claimable.add(claimedRewardAmounts[index]).raw)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,10 +2742,10 @@
   dependencies:
     "@swapr/core" "^0.3.17"
 
-"@swapr/sdk@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-0.11.0.tgz#60effd91cf3be4689b5fc18b01740c0d3e90a1cf"
-  integrity sha512-0qpLIEiD0y2rCCLuX2GybBoBzWbkveXm/PfG4Bc4QVuH1PSNHCY13eTx0vh8aPVTEQ4hFuWEP2sOv1c7J0HJZQ==
+"@swapr/sdk@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-0.11.1.tgz#cb889cddaad0119a6a1ccb8b87b82aef3bc1d9e4"
+  integrity sha512-BpHTOguDmfyoYHdl+v5HOGjCJvCLEWsNiS9+NSoKaLq/e6ANGsXY2UIiGhlwfGLJNC80pUxOJAC7Sr7hvoUBow==
   dependencies:
     "@makerdao/multicall" "^0.11.0"
     "@swapr/core" "^0.3.18"


### PR DESCRIPTION
An inconsistency was present between shown claimable/claimed tokens in multi-reward campaigns and the actual onchain data.
The inconsistency stems from the fact that rewards as indexed on the subgraph were used to determine which token amount was claimable/claimed. The claimable/claimed amounts were coming directly from the onchain state, and there was no guarantee that the order of the rewards was the same between the onchain distribution contract and the subgraph.

The fix consists in fetching the reward tokens (the addresses) exactly ordered as they are onchain and using those ordered addresses to get the token related to the claimed/claimable amounts. 