### PR TITLE
Fix for farming badge color on pairs page

### DIFF
--- a/src/components/Pool/PairsList/Pair/index.tsx
+++ b/src/components/Pool/PairsList/Pair/index.tsx
@@ -35,7 +35,10 @@ const SizedCard = styled(DarkCard)`
 const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
   height: 16px;
   border: ${props => !props.isGreyed && `solid 1.5px ${props.theme.green2}`};
-  color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.green2)};
+  div {
+    color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.green2)};
+  }
+
   border-radius: 6px;
   width: fit-content;
   display: flex;


### PR DESCRIPTION
# Summary

Fixes #678 

*Farming badge text color fix for pairs page*
![Screenshot 2022-03-07 at 14 32 38](https://user-images.githubusercontent.com/33226956/157043982-d26895c7-522d-45be-9557-4352e46dc216.png)



  # To Test

1. Go to pairs page and check if farming indicator text color is green as opposed to white 



