### PR TITLE
Feature/omnibridge tx history

### DIFF
--- a/src/pages/Bridge/Tabs.tsx
+++ b/src/pages/Bridge/Tabs.tsx
@@ -50,7 +50,7 @@ export const Tabs = ({
       </Button>
       <Button
         onClick={() => {
-          setTxsFilter(BridgeTxsFilter.RECENT)
+          setTxsFilter(BridgeTxsFilter.NONE)
           setActiveTab('history')
         }}
         className={activeTab === 'history' ? 'active' : ''}

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
-import { ChainId, CurrencyAmount } from '@swapr/sdk'
+import { ChainId, Currency, CurrencyAmount } from '@swapr/sdk'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Tabs } from './Tabs'
@@ -121,7 +121,8 @@ export default function Bridge() {
 
     if (collectableTx && collecting) {
       const { assetAddressL1, assetAddressL2, toChainId, fromChainId } = collectableTx
-      onCurrencySelection(assetAddressL1 && assetAddressL2 ? assetAddressL1 : 'ETH')
+
+      onCurrencySelection(assetAddressL1 && assetAddressL2 ? assetAddressL1 : Currency.getNative(toChainId) ?? '')
 
       if (chainId !== fromChainId && chainId !== toChainId) {
         setCollecting(false)
@@ -182,9 +183,11 @@ export default function Bridge() {
   const handleTriggerCollect = useCallback(
     (tx: BridgeTransactionSummary) => {
       //FIX tmp solution because collect won't work for all txs
-      if (tx.toChainId !== chainId && tx.fromChainId !== chainId) return
+      const { assetAddressL1, assetAddressL2, toChainId, fromChainId } = tx
+      if (toChainId !== chainId && fromChainId !== chainId) return
 
-      onCurrencySelection(tx.assetAddressL1 && tx.assetAddressL2 ? tx.assetAddressL1 : 'ETH')
+      onCurrencySelection(assetAddressL1 && assetAddressL2 ? assetAddressL1 : Currency.getNative(toChainId) ?? '')
+
       const collectData = omnibridge.triggerCollect(tx)
 
       setCollecting(true)

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
@@ -7,9 +7,10 @@ import {
   BridgeTxn,
   BridgeTxnsState
 } from '../../../state/bridgeTransactions/types'
-import { getBridgeTxStatus, PendingReasons, txnTypeToOrigin } from '../../../utils/arbitrum'
+import { getBridgeTxStatus, txnTypeToOrigin } from '../../../utils/arbitrum'
 import { ArbitrumList, BridgeTxsFilter } from '../Omnibridge.types'
 import { omnibridgeConfig } from '../Omnibridge.config'
+import { ArbitrumPendingReasons } from './ArbitrumBridge.types'
 
 const getSupportedChains = (bridgeId: string) => {
   const bridge = omnibridgeConfig.find(config => config.bridgeId === bridgeId)
@@ -125,7 +126,7 @@ const createSelectBridgeTxsSummary = (
           txHash: tx.txHash,
           batchIndex: tx.batchIndex,
           batchNumber: tx.batchNumber,
-          pendingReason: tx.receipt?.status ? undefined : PendingReasons.TX_UNCONFIRMED,
+          pendingReason: tx.receipt?.status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED,
           timestampResolved: tx.timestampResolved,
           log: [],
           bridgeId
@@ -133,7 +134,7 @@ const createSelectBridgeTxsSummary = (
         if (!tx.partnerTxHash || !l2Txs[tx.partnerTxHash]) {
           if (tx.type === 'deposit-l1' && tx.receipt?.status !== 0) {
             summary.status = 'pending' // deposits on l1 should never show confirmed on UI
-            summary.pendingReason = PendingReasons.TX_UNCONFIRMED
+            summary.pendingReason = ArbitrumPendingReasons.TX_UNCONFIRMED
           }
 
           summary.log = createBridgeLog({ transactions: [tx], fromChainId: from, toChainId: to })
@@ -149,7 +150,7 @@ const createSelectBridgeTxsSummary = (
           summary.fromChainId = to
           summary.toChainId = from
           summary.status = status === 1 ? 'claimed' : getBridgeTxStatus(status)
-          summary.pendingReason = status ? undefined : PendingReasons.TX_UNCONFIRMED
+          summary.pendingReason = status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED
           summary.log = createBridgeLog({
             transactions: [l2Txs[tx.partnerTxHash], tx],
             fromChainId: to,
@@ -169,7 +170,7 @@ const createSelectBridgeTxsSummary = (
             summary.status = 'failed'
           } else {
             summary.status = getBridgeTxStatus(statusL2)
-            summary.pendingReason = statusL2 ? undefined : PendingReasons.DESPOSIT
+            summary.pendingReason = statusL2 ? undefined : ArbitrumPendingReasons.DESPOSIT
             summary.timestampResolved = l2Txs[tx.partnerTxHash].timestampResolved
           }
 
@@ -225,7 +226,7 @@ const createSelectBridgeTxsSummary = (
                     break
                   default:
                     summary.status = 'pending'
-                    summary.pendingReason = PendingReasons.WITHDRAWAL
+                    summary.pendingReason = ArbitrumPendingReasons.WITHDRAWAL
                     summary.timestampResolved = undefined
                 }
               } else {

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
@@ -72,18 +72,12 @@ const createSelectPendingWithdrawals = (selectOwnedTxs: ReturnType<typeof create
     )
   })
 
-type CreateBridgeLogProps = Pick<BridgeTransactionSummary, 'fromChainId' | 'toChainId'> & {
-  transactions: BridgeTxn[]
-}
+type CreateBridgeLogProps = {}
 
-const createBridgeLog = ({ transactions, fromChainId, toChainId }: CreateBridgeLogProps): BridgeTransactionLog[] => {
+const createBridgeLog = (transactions: BridgeTxn[]): BridgeTransactionLog[] => {
   return transactions.map(tx => ({
     txHash: tx.txHash,
-    chainId: tx.chainId,
-    toChainId,
-    fromChainId,
-    type: tx.type,
-    status: getBridgeTxStatus(tx.receipt?.status)
+    chainId: tx.chainId
   }))
 }
 
@@ -137,7 +131,7 @@ const createSelectBridgeTxsSummary = (
             summary.pendingReason = ArbitrumPendingReasons.TX_UNCONFIRMED
           }
 
-          summary.log = createBridgeLog({ transactions: [tx], fromChainId: from, toChainId: to })
+          summary.log = createBridgeLog([tx])
           processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
 
           total.push(summary)
@@ -151,11 +145,7 @@ const createSelectBridgeTxsSummary = (
           summary.toChainId = from
           summary.status = status === 1 ? 'claimed' : getBridgeTxStatus(status)
           summary.pendingReason = status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED
-          summary.log = createBridgeLog({
-            transactions: [l2Txs[tx.partnerTxHash], tx],
-            fromChainId: to,
-            toChainId: from
-          })
+          summary.log = createBridgeLog([l2Txs[tx.partnerTxHash], tx])
 
           processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
           processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
@@ -174,11 +164,7 @@ const createSelectBridgeTxsSummary = (
             summary.timestampResolved = l2Txs[tx.partnerTxHash].timestampResolved
           }
 
-          summary.log = createBridgeLog({
-            transactions: [tx, l2Txs[tx.partnerTxHash]],
-            fromChainId: from,
-            toChainId: to
-          })
+          summary.log = createBridgeLog([tx, l2Txs[tx.partnerTxHash]])
 
           processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
           processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
@@ -237,7 +223,7 @@ const createSelectBridgeTxsSummary = (
               summary.timestampResolved = undefined
             }
           }
-          summary.log = createBridgeLog({ transactions: [tx], fromChainId: from, toChainId: to })
+          summary.log = createBridgeLog([tx])
 
           processedTxsMap[l2ChainId][tx.txHash] = tx.txHash
 

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
@@ -8,7 +8,7 @@ import {
   BridgeTxnsState
 } from '../../../state/bridgeTransactions/types'
 import { getBridgeTxStatus, txnTypeToOrigin } from '../../../utils/arbitrum'
-import { ArbitrumList, BridgeTxsFilter } from '../Omnibridge.types'
+import { ArbitrumList } from '../Omnibridge.types'
 import { omnibridgeConfig } from '../Omnibridge.config'
 import { ArbitrumPendingReasons } from './ArbitrumBridge.types'
 

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
@@ -72,8 +72,6 @@ const createSelectPendingWithdrawals = (selectOwnedTxs: ReturnType<typeof create
     )
   })
 
-type CreateBridgeLogProps = {}
-
 const createBridgeLog = (transactions: BridgeTxn[]): BridgeTransactionLog[] => {
   return transactions.map(tx => ({
     txHash: tx.txHash,

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.selectors.ts
@@ -85,170 +85,151 @@ const createSelectBridgeTxsSummary = (
   bridgeId: ArbitrumList,
   selectOwnedTxs: ReturnType<typeof createSelectOwnedTxs>
 ) =>
-  createSelector(
-    [
-      selectOwnedTxs,
-      (state: AppState) => state.omnibridge.UI.isCheckingWithdrawals,
-      (state: AppState) => state.omnibridge.UI.filter
-    ],
-    (txs, isLoading, txsFilter) => {
-      const [l1ChainId, l2ChainId] = Object.keys(txs).map(key => Number(key))
+  createSelector([selectOwnedTxs, (state: AppState) => state.omnibridge.UI.isCheckingWithdrawals], (txs, isLoading) => {
+    const [l1ChainId, l2ChainId] = Object.keys(txs).map(key => Number(key))
 
-      const l1Txs = txs[l1ChainId]
-      const l2Txs = txs[l2ChainId]
+    const l1Txs = txs[l1ChainId]
+    const l2Txs = txs[l2ChainId]
 
-      const processedTxsMap: {
-        [chainId: number]: {
-          [txHash: string]: string
-        }
-      } = { [l1ChainId]: {}, [l2ChainId]: {} }
+    const processedTxsMap: {
+      [chainId: number]: {
+        [txHash: string]: string
+      }
+    } = { [l1ChainId]: {}, [l2ChainId]: {} }
 
-      const l1Summaries = Object.values(l1Txs ?? {}).reduce<BridgeTransactionSummary[]>((total, tx) => {
-        const from = txnTypeToOrigin(tx.type) === 1 ? l1ChainId : l2ChainId
-        const to = from === l1ChainId ? l2ChainId : l1ChainId
+    const l1Summaries = Object.values(l1Txs ?? {}).reduce<BridgeTransactionSummary[]>((total, tx) => {
+      const from = txnTypeToOrigin(tx.type) === 1 ? l1ChainId : l2ChainId
+      const to = from === l1ChainId ? l2ChainId : l1ChainId
 
-        if (processedTxsMap[l1ChainId][tx.txHash]) return total
+      if (processedTxsMap[l1ChainId][tx.txHash]) return total
 
-        const summary: BridgeTransactionSummary = {
-          assetName: tx.assetName,
-          assetAddressL1: tx.assetAddressL1,
-          assetAddressL2: tx.assetAddressL2,
-          fromChainId: from,
-          toChainId: to,
-          status: getBridgeTxStatus(tx.receipt?.status),
-          value: tx.value,
-          txHash: tx.txHash,
-          batchIndex: tx.batchIndex,
-          batchNumber: tx.batchNumber,
-          pendingReason: tx.receipt?.status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED,
-          timestampResolved: tx.timestampResolved,
-          log: [],
-          bridgeId
-        }
-        if (!tx.partnerTxHash || !l2Txs[tx.partnerTxHash]) {
-          if (tx.type === 'deposit-l1' && tx.receipt?.status !== 0) {
-            summary.status = 'pending' // deposits on l1 should never show confirmed on UI
-            summary.pendingReason = ArbitrumPendingReasons.TX_UNCONFIRMED
-          }
-
-          summary.log = createBridgeLog([tx])
-          processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
-
-          total.push(summary)
-          return total
+      const summary: BridgeTransactionSummary = {
+        assetName: tx.assetName,
+        assetAddressL1: tx.assetAddressL1,
+        assetAddressL2: tx.assetAddressL2,
+        fromChainId: from,
+        toChainId: to,
+        status: getBridgeTxStatus(tx.receipt?.status),
+        value: tx.value,
+        txHash: tx.txHash,
+        batchIndex: tx.batchIndex,
+        batchNumber: tx.batchNumber,
+        pendingReason: tx.receipt?.status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED,
+        timestampResolved: tx.timestampResolved,
+        log: [],
+        bridgeId
+      }
+      if (!tx.partnerTxHash || !l2Txs[tx.partnerTxHash]) {
+        if (tx.type === 'deposit-l1' && tx.receipt?.status !== 0) {
+          summary.status = 'pending' // deposits on l1 should never show confirmed on UI
+          summary.pendingReason = ArbitrumPendingReasons.TX_UNCONFIRMED
         }
 
-        if (tx.type === 'outbox') {
-          const status = tx.receipt?.status
+        summary.log = createBridgeLog([tx])
+        processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
 
-          summary.fromChainId = to
-          summary.toChainId = from
-          summary.status = status === 1 ? 'claimed' : getBridgeTxStatus(status)
-          summary.pendingReason = status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED
-          summary.log = createBridgeLog([l2Txs[tx.partnerTxHash], tx])
-
-          processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
-          processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
-
-          total.push(summary)
-          return total
-        }
-
-        if (tx.type === 'deposit-l1' && tx.receipt) {
-          const statusL2 = l2Txs[tx.partnerTxHash].receipt?.status
-          if (tx.receipt?.status === 0 || statusL2 === 0) {
-            summary.status = 'failed'
-          } else {
-            summary.status = getBridgeTxStatus(statusL2)
-            summary.pendingReason = statusL2 ? undefined : ArbitrumPendingReasons.DESPOSIT
-            summary.timestampResolved = l2Txs[tx.partnerTxHash].timestampResolved
-          }
-
-          summary.log = createBridgeLog([tx, l2Txs[tx.partnerTxHash]])
-
-          processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
-          processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
-
-          total.push(summary)
-          return total
-        }
+        total.push(summary)
         return total
-      }, [])
+      }
 
-      const l2Summaries = Object.values(l2Txs ?? {}).reduce<BridgeTransactionSummary[]>((total, tx) => {
-        const from = txnTypeToOrigin(tx.type) === 1 ? l1ChainId : l2ChainId
-        const to = from === l1ChainId ? l2ChainId : l1ChainId
+      if (tx.type === 'outbox') {
+        const status = tx.receipt?.status
 
-        if (processedTxsMap[l2ChainId][tx.txHash]) return total
+        summary.fromChainId = to
+        summary.toChainId = from
+        summary.status = status === 1 ? 'claimed' : getBridgeTxStatus(status)
+        summary.pendingReason = status ? undefined : ArbitrumPendingReasons.TX_UNCONFIRMED
+        summary.log = createBridgeLog([l2Txs[tx.partnerTxHash], tx])
 
-        const summary: BridgeTransactionSummary = {
-          assetName: tx.assetName,
-          assetAddressL1: tx.assetAddressL1,
-          assetAddressL2: tx.assetAddressL2,
-          value: tx.value,
-          txHash: tx.txHash,
-          batchNumber: tx.batchNumber,
-          batchIndex: tx.batchIndex,
-          fromChainId: from,
-          toChainId: to,
-          status: getBridgeTxStatus(tx.receipt?.status),
-          timestampResolved: tx.timestampResolved,
-          log: [],
-          bridgeId
+        processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
+        processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
+
+        total.push(summary)
+        return total
+      }
+
+      if (tx.type === 'deposit-l1' && tx.receipt) {
+        const statusL2 = l2Txs[tx.partnerTxHash].receipt?.status
+        if (tx.receipt?.status === 0 || statusL2 === 0) {
+          summary.status = 'failed'
+        } else {
+          summary.status = getBridgeTxStatus(statusL2)
+          summary.pendingReason = statusL2 ? undefined : ArbitrumPendingReasons.DESPOSIT
+          summary.timestampResolved = l2Txs[tx.partnerTxHash].timestampResolved
         }
 
-        // WITHDRAWAL L2
-        if (!tx.partnerTxHash || !l1Txs[tx.partnerTxHash]) {
-          if (tx.type === 'withdraw') {
-            if (!isLoading) {
-              if (tx.receipt?.status !== 0) {
-                switch (tx.outgoingMessageState) {
-                  case OutgoingMessageState.CONFIRMED:
-                    summary.status = 'redeem'
-                    summary.timestampResolved = undefined
-                    break
-                  case OutgoingMessageState.EXECUTED:
-                    summary.status = 'claimed'
-                    break
-                  default:
-                    summary.status = 'pending'
-                    summary.pendingReason = ArbitrumPendingReasons.WITHDRAWAL
-                    summary.timestampResolved = undefined
-                }
-              } else {
-                summary.status = 'failed'
+        summary.log = createBridgeLog([tx, l2Txs[tx.partnerTxHash]])
+
+        processedTxsMap[l1ChainId][tx.txHash] = tx.txHash
+        processedTxsMap[l2ChainId][tx.partnerTxHash] = tx.partnerTxHash // skip partner tx in l2Summaries
+
+        total.push(summary)
+        return total
+      }
+      return total
+    }, [])
+
+    const l2Summaries = Object.values(l2Txs ?? {}).reduce<BridgeTransactionSummary[]>((total, tx) => {
+      const from = txnTypeToOrigin(tx.type) === 1 ? l1ChainId : l2ChainId
+      const to = from === l1ChainId ? l2ChainId : l1ChainId
+
+      if (processedTxsMap[l2ChainId][tx.txHash]) return total
+
+      const summary: BridgeTransactionSummary = {
+        assetName: tx.assetName,
+        assetAddressL1: tx.assetAddressL1,
+        assetAddressL2: tx.assetAddressL2,
+        value: tx.value,
+        txHash: tx.txHash,
+        batchNumber: tx.batchNumber,
+        batchIndex: tx.batchIndex,
+        fromChainId: from,
+        toChainId: to,
+        status: getBridgeTxStatus(tx.receipt?.status),
+        timestampResolved: tx.timestampResolved,
+        log: [],
+        bridgeId
+      }
+
+      // WITHDRAWAL L2
+      if (!tx.partnerTxHash || !l1Txs[tx.partnerTxHash]) {
+        if (tx.type === 'withdraw') {
+          if (!isLoading) {
+            if (tx.receipt?.status !== 0) {
+              switch (tx.outgoingMessageState) {
+                case OutgoingMessageState.CONFIRMED:
+                  summary.status = 'redeem'
+                  summary.timestampResolved = undefined
+                  break
+                case OutgoingMessageState.EXECUTED:
+                  summary.status = 'claimed'
+                  break
+                default:
+                  summary.status = 'pending'
+                  summary.pendingReason = ArbitrumPendingReasons.WITHDRAWAL
+                  summary.timestampResolved = undefined
               }
             } else {
-              summary.status = 'loading'
-              summary.timestampResolved = undefined
+              summary.status = 'failed'
             }
+          } else {
+            summary.status = 'loading'
+            summary.timestampResolved = undefined
           }
-          summary.log = createBridgeLog([tx])
-
-          processedTxsMap[l2ChainId][tx.txHash] = tx.txHash
-
-          total.push(summary)
-          return total
         }
+        summary.log = createBridgeLog([tx])
 
+        processedTxsMap[l2ChainId][tx.txHash] = tx.txHash
+
+        total.push(summary)
         return total
-      }, [])
-      const retVal = [...l1Summaries, ...l2Summaries].reverse()
-
-      switch (txsFilter) {
-        case BridgeTxsFilter.COLLECTABLE:
-          return retVal.filter(summary => summary.status === 'redeem')
-        case BridgeTxsFilter.RECENT:
-          const passed24h = new Date().getTime() - 1000 * 60 * 60 * 24
-          return retVal.filter(summary => {
-            if (!summary.timestampResolved) return true
-            return summary.timestampResolved >= passed24h
-          })
-        default:
-          return retVal
       }
-    }
-  )
+
+      return total
+    }, [])
+
+    return [...l1Summaries, ...l2Summaries].reverse()
+  })
 
 const createSelectBridgingDetails = (bridgeId: ArbitrumList) =>
   createSelector(

--- a/src/services/Omnibridge/Arbitrum/ArbitrumBridge.types.ts
+++ b/src/services/Omnibridge/Arbitrum/ArbitrumBridge.types.ts
@@ -1,6 +1,12 @@
 import { ChainId } from '@swapr/sdk'
 import { TokenInfo, TokenList } from '@uniswap/token-lists'
 
+export const ArbitrumPendingReasons = {
+  TX_UNCONFIRMED: 'Transaction has not been confirmed yet',
+  DESPOSIT: 'Waiting for deposit to be processed on L2 (~10 minutes)',
+  WITHDRAWAL: 'Waiting for confirmation (~7 days of dispute period)'
+}
+
 export type ArbitrumTokenInfo = Omit<TokenInfo, 'extensions'> & {
   extensions: {
     bridgeInfo: {

--- a/src/services/Omnibridge/Socket/Socket.reducer.ts
+++ b/src/services/Omnibridge/Socket/Socket.reducer.ts
@@ -85,21 +85,39 @@ const createSocketSlice = (bridgeId: SocketList) =>
         state,
         action: PayloadAction<{
           txHash: string
+          partnerTxHash?: string
           assetName: string
           value: string
           fromChainId: ChainId
           toChainId: ChainId
           bridgeId: BridgeList
+          status?: 'success' | 'pending' | 'error'
+          sender: string
         }>
       ) => {
         const { payload: txn } = action
 
         state.transactions.push(txn)
       },
-      updateTx: (state, action: PayloadAction<{ txHash: string }>) => {
-        const index = state.transactions.findIndex(tx => tx.txHash === action.payload.txHash)
+      updateTx: (
+        state,
+        action: PayloadAction<{ txHash: string; partnerTxHash?: string; status?: 'success' | 'pending' | 'error' }>
+      ) => {
+        const { txHash, partnerTxHash, status } = action.payload
+        const index = state.transactions.findIndex(tx => tx.txHash === txHash)
+        const tx = state.transactions[index]
 
-        state.transactions[index].timestampResolved = Date.now()
+        if (status) {
+          tx.status = status
+
+          if (status === 'success') {
+            tx.timestampResolved = Date.now()
+          }
+        }
+
+        if (partnerTxHash) {
+          tx.partnerTxHash = partnerTxHash
+        }
       },
       setRoutes: (state, action: PayloadAction<Route[]>) => {
         state.routes = action.payload

--- a/src/services/Omnibridge/Socket/Socket.selectors.ts
+++ b/src/services/Omnibridge/Socket/Socket.selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect'
 import { AppState } from '../../../state'
-import { BridgeTransactionLog, BridgeTransactionSummary } from '../../../state/bridgeTransactions/types'
+import { BridgeTransactionSummary } from '../../../state/bridgeTransactions/types'
 import { BridgeTxsFilter, SocketList } from '../Omnibridge.types'
 import { SocketTx, SOCKET_PENDING_REASONS } from './Socket.types'
 
@@ -70,13 +70,6 @@ const createSelectBridgeTxsSummary = (bridgeId: SocketList, selectOwnedTxs: Retu
           ? SOCKET_PENDING_REASONS.TO_PENDING
           : undefined
 
-      const txLogBase: Omit<BridgeTransactionLog, 'txHash' | 'chainId'> = {
-        toChainId: tx.toChainId,
-        fromChainId: tx.fromChainId,
-        status: 'confirmed',
-        type: 'deposit'
-      }
-
       const summary: BridgeTransactionSummary = {
         assetName: tx.assetName,
         assetAddressL1: '', // not applicable, socket doesn't implement collect flow for now
@@ -90,7 +83,6 @@ const createSelectBridgeTxsSummary = (bridgeId: SocketList, selectOwnedTxs: Retu
         timestampResolved: tx.timestampResolved,
         log: [
           {
-            ...txLogBase,
             chainId: tx.fromChainId,
             txHash: tx.txHash
           }
@@ -100,7 +92,6 @@ const createSelectBridgeTxsSummary = (bridgeId: SocketList, selectOwnedTxs: Retu
 
       if (tx.partnerTxHash) {
         summary.log.push({
-          ...txLogBase,
           chainId: tx.toChainId,
           txHash: tx.partnerTxHash
         })

--- a/src/services/Omnibridge/Socket/Socket.selectors.ts
+++ b/src/services/Omnibridge/Socket/Socket.selectors.ts
@@ -1,6 +1,9 @@
 import { createSelector } from 'reselect'
 import { AppState } from '../../../state'
-import { SocketList } from '../Omnibridge.types'
+import { BridgeTransactionSummary } from '../../../state/bridgeTransactions/types'
+import { PendingReasons } from '../../../utils/arbitrum'
+import { BridgeTxsFilter, SocketList } from '../Omnibridge.types'
+import { SocketTx } from './Socket.types'
 
 const createSelectBridgingDetails = (bridgeId: SocketList) =>
   createSelector(
@@ -28,26 +31,106 @@ const createSelectApprovalData = (bridgeId: SocketList) =>
 const createSelectTxBridgingData = (bridgeId: SocketList) =>
   createSelector([(state: AppState) => state.omnibridge[bridgeId].txBridgingData], txBridgingData => txBridgingData)
 
-//TODO selector for txs
+const createSelectOwnedTxs = (bridgeId: SocketList) =>
+  createSelector(
+    [
+      (state: AppState) => state.omnibridge[bridgeId].transactions,
+      (state: AppState, account: string | undefined) => account
+    ],
+    (txs, account) => {
+      let ownedTxs: SocketTx[] = []
+
+      if (account) {
+        ownedTxs = txs.reduce<SocketTx[]>((filteredTxs, tx) => {
+          if (account.toLocaleLowerCase() === tx.sender.toLocaleLowerCase()) {
+            filteredTxs.push(tx)
+          }
+
+          return filteredTxs
+        }, [])
+      }
+
+      return ownedTxs
+    }
+  )
+
+const createSelectPendingTxs = (selectOwnedTxs: ReturnType<typeof createSelectOwnedTxs>) =>
+  createSelector(selectOwnedTxs, ownedTxs => {
+    const pendingTxs = ownedTxs.filter(tx => tx.status === 'pending' || !tx.partnerTxHash)
+
+    return pendingTxs
+  })
+
+const createSelectBridgeTxsSummary = (bridgeId: SocketList, selectOwnedTxs: ReturnType<typeof createSelectOwnedTxs>) =>
+  createSelector([selectOwnedTxs, (state: AppState) => state.omnibridge.UI.filter], (txs, txsFilter) => {
+    const summaries = txs.map(tx => {
+      const summary: BridgeTransactionSummary = {
+        assetName: tx.assetName,
+        assetAddressL1: '', // used by collect
+        assetAddressL2: '', // used by collect
+        fromChainId: tx.fromChainId,
+        toChainId: tx.toChainId,
+        status: tx.status === 'error' ? 'failed' : tx.status === 'pending' ? 'loading' : 'confirmed',
+        value: tx.value,
+        txHash: tx.txHash,
+        pendingReason: tx.status === 'pending' ? PendingReasons.TX_UNCONFIRMED : undefined,
+        timestampResolved: tx.timestampResolved,
+        log: [
+          {
+            chainId: tx.fromChainId,
+            fromChainId: tx.fromChainId,
+            status: tx.status === 'error' ? 'failed' : tx.status === 'pending' ? 'loading' : 'confirmed',
+            txHash: tx.txHash,
+            type: 'deposit',
+            toChainId: tx.toChainId
+          }
+        ],
+        bridgeId
+      }
+      return summary
+    })
+
+    switch (txsFilter) {
+      case BridgeTxsFilter.COLLECTABLE:
+        return summaries.filter(summary => summary.status === 'redeem')
+      case BridgeTxsFilter.RECENT:
+        const passed24h = new Date().getTime() - 1000 * 60 * 60 * 24
+        return summaries.filter(summary => {
+          if (!summary.timestampResolved) return true
+          return summary.timestampResolved >= passed24h
+        })
+      default:
+        return summaries
+    }
+  })
 
 export interface SocketBridgeSelectors {
   selectBridgingDetails: ReturnType<typeof createSelectBridgingDetails>
   selectRoutes: ReturnType<typeof createSelectRoutes>
   selectApprovalData: ReturnType<typeof createSelectApprovalData>
   selectTxBridgingData: ReturnType<typeof createSelectTxBridgingData>
+  selectOwnedTxs: ReturnType<typeof createSelectOwnedTxs>
+  selectPendingTxs: ReturnType<typeof createSelectPendingTxs>
+  selectBridgeTxsSummary: ReturnType<typeof createSelectBridgeTxsSummary>
 }
 export const socketSelectorsFactory = (socketBridges: SocketList[]) => {
   return socketBridges.reduce((total, bridgeId) => {
+    const selectOwnedTxs = createSelectOwnedTxs(bridgeId)
     const selectBridgingDetails = createSelectBridgingDetails(bridgeId)
     const selectRoutes = createSelectRoutes(bridgeId)
     const selectApprovalData = createSelectApprovalData(bridgeId)
     const selectTxBridgingData = createSelectTxBridgingData(bridgeId)
+    const selectPendingTxs = createSelectPendingTxs(selectOwnedTxs)
+    const selectBridgeTxsSummary = createSelectBridgeTxsSummary(bridgeId, selectOwnedTxs)
 
     const selectors = {
       selectBridgingDetails,
       selectRoutes,
       selectApprovalData,
-      selectTxBridgingData
+      selectTxBridgingData,
+      selectOwnedTxs,
+      selectPendingTxs,
+      selectBridgeTxsSummary
     }
 
     total[bridgeId] = selectors

--- a/src/services/Omnibridge/Socket/Socket.types.ts
+++ b/src/services/Omnibridge/Socket/Socket.types.ts
@@ -3,7 +3,14 @@ import { TokenList } from '@uniswap/token-lists'
 import { BridgeList, AsyncState, BridgingDetailsErrorMessage } from '../Omnibridge.types'
 import { Route } from './api/generated'
 
+export const SOCKET_PENDING_REASONS = {
+  FROM_PENDING: 'Transaction on source chain has not been confirmed yet',
+  TO_PENDING: 'Transaction on destination chain has not been confirmed yet'
+}
+
 export const SOCKET_NATIVE_TOKEN_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+export type SocketTxStatus = 'from-pending' | 'to-pending' | 'error' | 'confirmed'
 
 export type SocketTx = {
   txHash: string
@@ -14,7 +21,7 @@ export type SocketTx = {
   toChainId: ChainId
   bridgeId: BridgeList
   timestampResolved?: number
-  status?: 'pending' | 'success' | 'error'
+  status: SocketTxStatus
   sender: string
 }
 export interface SocketBridgeState {

--- a/src/services/Omnibridge/Socket/Socket.types.ts
+++ b/src/services/Omnibridge/Socket/Socket.types.ts
@@ -5,16 +5,20 @@ import { Route } from './api/generated'
 
 export const SOCKET_NATIVE_TOKEN_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
+export type SocketTx = {
+  txHash: string
+  partnerTxHash?: string
+  assetName: string
+  value: string
+  fromChainId: ChainId
+  toChainId: ChainId
+  bridgeId: BridgeList
+  timestampResolved?: number
+  status?: 'pending' | 'success' | 'error'
+  sender: string
+}
 export interface SocketBridgeState {
-  transactions: {
-    txHash: string
-    assetName: string
-    value: string
-    fromChainId: ChainId
-    toChainId: ChainId
-    bridgeId: BridgeList
-    timestampResolved?: number
-  }[]
+  transactions: SocketTx[]
   bridgingDetails: {
     gas?: string
     fee?: string

--- a/src/services/Omnibridge/Socket/SocketBridge.ts
+++ b/src/services/Omnibridge/Socket/SocketBridge.ts
@@ -517,7 +517,9 @@ export class SocketBridge extends OmnibridgeChildBase {
     this.store.dispatch(this.actions.setTokenListsStatus('ready'))
   }
 
-  public fetchStaticLists = async () => undefined
+  public fetchStaticLists = async () => {
+    this.store.dispatch(commonActions.activateLists(['socket']))
+  }
 
   public triggerModalDisclaimerText = () => {
     this.store.dispatch(omnibridgeUIActions.setModalDisclaimerText('Content to be discussed'))

--- a/src/services/Omnibridge/Socket/SocketBridge.ts
+++ b/src/services/Omnibridge/Socket/SocketBridge.ts
@@ -1,3 +1,4 @@
+import { Currency } from '@swapr/sdk'
 import { formatUnits, parseUnits } from '@ethersproject/units'
 import {
   OmnibridgeChildBaseConstructor,
@@ -72,8 +73,9 @@ export class SocketBridge extends OmnibridgeChildBase {
       !from.address ||
       !from.chainId ||
       !from.value ||
-      !to.chainId ||
-      !from.address
+      !from.address ||
+      !from.symbol ||
+      !to.chainId
     )
       return
 
@@ -91,7 +93,7 @@ export class SocketBridge extends OmnibridgeChildBase {
         this.actions.addTx({
           sender: this._account,
           txHash: tx.hash,
-          assetName: 'AssetNameToAdd',
+          assetName: from.symbol,
           value: from.value,
           fromChainId: from.chainId,
           toChainId: to.chainId,
@@ -301,7 +303,7 @@ export class SocketBridge extends OmnibridgeChildBase {
     let fromTokenAddress: string = SOCKET_NATIVE_TOKEN_ADDRESS
     let toTokenAddress: string = SOCKET_NATIVE_TOKEN_ADDRESS
 
-    if (from.address !== 'ETH') {
+    if (from.address !== Currency.getNative(from.chainId).symbol) {
       //way to find from and toToken
       const fromToken = socketTokens.tokens.find(token => token.address.toLowerCase() === from.address.toLowerCase())
       if (!fromToken) {

--- a/src/services/Omnibridge/hooks/Omnibrige.hooks.ts
+++ b/src/services/Omnibridge/hooks/Omnibrige.hooks.ts
@@ -127,7 +127,9 @@ export function useBridgeActionHandlers(): {
       dispatch(
         omnibridgeUIActions.setFrom({
           address: currency instanceof Currency ? currencyId(currency) : currency,
-          decimals: currency instanceof Currency ? currency.decimals : undefined
+          decimals: currency instanceof Currency ? currency.decimals : undefined,
+          name: currency instanceof Currency ? currency.name : '',
+          symbol: currency instanceof Currency ? currency.symbol : ''
         })
       )
       // dispatch(omnibridgeUIActions.setTo({ address: currency instanceof Currency ? currencyId(currency) : currency }))

--- a/src/services/Omnibridge/store/Omnibridge.selectors.ts
+++ b/src/services/Omnibridge/store/Omnibridge.selectors.ts
@@ -17,7 +17,7 @@ export const selectAllTransactions = createSelector(
 
   (txsSummaryTestnet, txsSummaryMainnet, txsSummarySocket, txsFilter) => {
     const txs = [...txsSummaryTestnet, ...txsSummaryMainnet, ...txsSummarySocket]
-    console.log({ txsFilter })
+
     switch (txsFilter) {
       case BridgeTxsFilter.COLLECTABLE:
         return txs.filter(summary => summary.status === 'redeem')

--- a/src/services/Omnibridge/store/Omnibridge.selectors.ts
+++ b/src/services/Omnibridge/store/Omnibridge.selectors.ts
@@ -10,10 +10,15 @@ import { socketSelectors } from '../Socket/Socket.selectors'
 export const selectAllTransactions = createSelector(
   [
     arbitrumSelectors['arbitrum:testnet'].selectBridgeTxsSummary,
-    arbitrumSelectors['arbitrum:mainnet'].selectBridgeTxsSummary
+    arbitrumSelectors['arbitrum:mainnet'].selectBridgeTxsSummary,
+    socketSelectors['socket'].selectBridgeTxsSummary
   ],
 
-  (txsSummaryTestnet, txsSummaryMainnet) => [...txsSummaryTestnet, ...txsSummaryMainnet]
+  (txsSummaryTestnet, txsSummaryMainnet, txsSummarySocket) => [
+    ...txsSummaryTestnet,
+    ...txsSummaryMainnet,
+    ...txsSummarySocket
+  ]
 )
 
 export const selectAllLists = createSelector(

--- a/src/services/Omnibridge/store/Omnibridge.selectors.ts
+++ b/src/services/Omnibridge/store/Omnibridge.selectors.ts
@@ -3,7 +3,7 @@ import { ChainId, Token } from '@swapr/sdk'
 import { AppState } from '../../../state'
 import { listToTokenMap } from '../../../state/lists/hooks'
 import { arbitrumSelectors } from '../Arbitrum/ArbitrumBridge.selectors'
-import { BridgeList, SupportedBridges, TokenMap } from '../Omnibridge.types'
+import { BridgeList, BridgeTxsFilter, SupportedBridges, TokenMap } from '../Omnibridge.types'
 import { omnibridgeConfig } from '../Omnibridge.config'
 import { socketSelectors } from '../Socket/Socket.selectors'
 
@@ -11,14 +11,26 @@ export const selectAllTransactions = createSelector(
   [
     arbitrumSelectors['arbitrum:testnet'].selectBridgeTxsSummary,
     arbitrumSelectors['arbitrum:mainnet'].selectBridgeTxsSummary,
-    socketSelectors['socket'].selectBridgeTxsSummary
+    socketSelectors['socket'].selectBridgeTxsSummary,
+    (state: AppState) => state.omnibridge.UI.filter
   ],
 
-  (txsSummaryTestnet, txsSummaryMainnet, txsSummarySocket) => [
-    ...txsSummaryTestnet,
-    ...txsSummaryMainnet,
-    ...txsSummarySocket
-  ]
+  (txsSummaryTestnet, txsSummaryMainnet, txsSummarySocket, txsFilter) => {
+    const txs = [...txsSummaryTestnet, ...txsSummaryMainnet, ...txsSummarySocket]
+    console.log({ txsFilter })
+    switch (txsFilter) {
+      case BridgeTxsFilter.COLLECTABLE:
+        return txs.filter(summary => summary.status === 'redeem')
+      case BridgeTxsFilter.RECENT:
+        const passed24h = new Date().getTime() - 1000 * 60 * 60 * 24
+        return txs.filter(summary => {
+          if (!summary.timestampResolved) return true
+          return summary.timestampResolved >= passed24h
+        })
+      default:
+        return txs
+    }
+  }
 )
 
 export const selectAllLists = createSelector(

--- a/src/services/Omnibridge/store/UI.reducer.ts
+++ b/src/services/Omnibridge/store/UI.reducer.ts
@@ -7,6 +7,8 @@ type OmnibridgeInput = {
   chainId: ChainId
   address: string
   decimals?: number
+  name?: string
+  symbol?: string
 }
 
 type UIInitialState = Record<'from' | 'to', OmnibridgeInput> & {
@@ -60,8 +62,8 @@ export const omnibridgeUISlice = createSlice({
   name: 'UI',
   initialState,
   reducers: {
-    setFrom(state, action: PayloadAction<{ address?: string; value?: string; chainId?: ChainId; decimals?: number }>) {
-      const { address, value, chainId, decimals } = action.payload
+    setFrom(state, action: PayloadAction<Partial<OmnibridgeInput>>) {
+      const { address, value, chainId, decimals, name, symbol } = action.payload
       if (address !== undefined) {
         state.from.address = address
       }
@@ -73,11 +75,20 @@ export const omnibridgeUISlice = createSlice({
       if (chainId) {
         state.from.chainId = chainId
       }
+
       if (decimals) {
         state.from.decimals = decimals
       }
+
+      if (name) {
+        state.from.name = name
+      }
+
+      if (symbol) {
+        state.from.symbol = symbol
+      }
     },
-    setTo(state, action: PayloadAction<{ address?: string; value?: string; chainId?: ChainId }>) {
+    setTo(state, action: PayloadAction<Partial<OmnibridgeInput>>) {
       const { address, value, chainId } = action.payload
       if (address !== undefined) {
         state.to.address = address

--- a/src/state/bridgeTransactions/types.ts
+++ b/src/state/bridgeTransactions/types.ts
@@ -68,7 +68,4 @@ export type BridgeTransactionSummary = Pick<
   pendingReason?: string
 }
 
-export type BridgeTransactionLog = Pick<BridgeTxn, 'txHash' | 'type' | 'chainId'> &
-  Pick<BridgeTransactionSummary, 'fromChainId' | 'toChainId'> & {
-    status: BridgeTransactionStatus
-  }
+export type BridgeTransactionLog = Pick<BridgeTxn, 'txHash' | 'chainId'>

--- a/src/utils/arbitrum.ts
+++ b/src/utils/arbitrum.ts
@@ -44,12 +44,6 @@ export const getChainPair = (chainId?: ChainId): ChainIdPair => {
   }
 }
 
-export const PendingReasons = {
-  TX_UNCONFIRMED: 'Transaction has not been confirmed yet',
-  DESPOSIT: 'Waiting for deposit to be processed on L2 (~10 minutes)',
-  WITHDRAWAL: 'Waiting for confirmation (~7 days of dispute period)'
-}
-
 export const getBridgeTxStatus = (txStatus: number | undefined): 'failed' | 'confirmed' | 'pending' => {
   switch (txStatus) {
     case 0:


### PR DESCRIPTION
# Summary

Closes #695

- added Socket transactions support
- tx filtering is done on omnibridge selector rather than single bridges
- socket list is enabled by default
- UI keeps track of asset name and symbol